### PR TITLE
feat: send shippingAddresses and billingAddresses to the server

### DIFF
--- a/eCommerce-Application/src/api/customer/create-customer.ts
+++ b/eCommerce-Application/src/api/customer/create-customer.ts
@@ -9,6 +9,7 @@ import {
   MyCustomerDraft,
 } from '@commercetools/platform-sdk';
 import { login } from './autorizate-customer';
+import { MyCustomerDraftExtended } from '../../types/types';
 
 export async function singUp(object: Record<string, string>): Promise<ClientResponse<CustomerSignInResult>> {
   const customer: MyCustomerDraft = createdCustomer(object);
@@ -66,13 +67,15 @@ export const createdCustomer = (object: Record<string, string>): MyCustomerDraft
 
   arrayAddresses.filter((object_) => Object.values(object_).every((value) => value !== undefined));
 
-  const customerDraft: MyCustomerDraft = {
+  const customerDraft: MyCustomerDraftExtended = {
     firstName: object.name,
     lastName: object.lastName,
     email: object.email,
     password: object.password,
     dateOfBirth: new Date(object.date).toLocaleDateString('sv-SE'),
     addresses: arrayAddresses,
+    shippingAddresses: [arrayAddresses.indexOf(shippingAddress)],
+    billingAddresses: [arrayAddresses.indexOf(billingAddress)],
     ...(object?.defaultShippingAddressChecker && { defaultShippingAddress: arrayAddresses.indexOf(shippingAddress) }),
     ...((object?.defaultBillingAddressChecker ||
       (object?.defaultShippingAddressChecker && object?.theSameShippingBillingAddressChecker)) && {
@@ -80,5 +83,7 @@ export const createdCustomer = (object: Record<string, string>): MyCustomerDraft
     }),
   };
 
-  return Object.fromEntries(Object.entries(customerDraft).filter((entry) => entry[1] !== -1)) as MyCustomerDraft;
+  return Object.fromEntries(
+    Object.entries(customerDraft).filter((entry) => entry[1] !== -1),
+  ) as MyCustomerDraftExtended;
 };

--- a/eCommerce-Application/src/types/types.ts
+++ b/eCommerce-Application/src/types/types.ts
@@ -1,3 +1,5 @@
+import { MyCustomerDraft } from '@commercetools/platform-sdk';
+
 export type FieldType = {
   name?: string;
   lastName?: string;
@@ -21,3 +23,8 @@ export type PostalCodeFormat = {
   pattern: RegExp;
   message: string;
 };
+
+export interface MyCustomerDraftExtended extends MyCustomerDraft {
+  shippingAddresses?: Array<number>;
+  billingAddresses?: Array<number>;
+}


### PR DESCRIPTION
1. Task: send shippingAddresses and billingAddresses to the server

2. Screenshot: 
<img width="703" alt="Снимок экрана 2025-05-21 в 12 01 25" src="https://github.com/user-attachments/assets/f4ee3545-8c8b-4d9a-8b37-1c80c632a727" />
<img width="391" alt="Снимок экрана 2025-05-21 в 12 01 36" src="https://github.com/user-attachments/assets/c7138fbc-6a86-4784-a60b-806cc7dc2591" />

3. Mentions: @artmigalev @dmalashev 

4. Brief description: Extend MyCustomerDraft and add shippingAddresses and billingAddresses fields. Send these fields to the server during registration
 
